### PR TITLE
default path needs to change for kubectl config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,7 @@ Once complete you will see the following output in your terminal:
 ### Setup complete:
 
 To interact with Kubernetes set your KUBECONFIG environment variable
-export KUBECONFIG="$HOME/.shipyard/shipyard/kubeconfig.yml"
+export KUBECONFIG="$HOME/.shipyard/yards/shipyard/kubeconfig.yml"
 
 Consul can be accessed at: http://localhost:8500
 Kubernetes dashboard can be accessed at: http://localhost:8443


### PR DESCRIPTION
When I followed the initial docs for installing and setting up kubectl, I was unable to run commands to discover the newly created pods, etc. I had to alter the KUBECONFIG path slightly.